### PR TITLE
Add unhealthy nodes tracking to Karpenter status poller

### DIFF
--- a/chart/permissions.yaml
+++ b/chart/permissions.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csv-creator-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-nodeclaim-reader
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["karpenter.sh"]
+  resources: ["nodeclaims"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csv-creator-binding
+subjects:
+- kind: ServiceAccount
+  name: csv-creator-sa
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: node-nodeclaim-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/chart/pod.yaml
+++ b/chart/pod.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csv-creator
+spec:
+  serviceAccountName: csv-creator-sa
+  containers:
+  - name: csv-creator
+    image: <Update with Container Image>
+    resources:
+      requests:
+        cpu: "10"
+        memory: "20Gi"
+      limits:
+        cpu: "10"
+        memory: "20Gi"
+    volumeMounts:
+    - name: data-volume
+      mountPath: /app
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+    effect: "NoSchedule"
+  volumes:
+  - name: data-volume
+    emptyDir: {}
+  priorityClassName: system-cluster-critical

--- a/main.go
+++ b/main.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
+	"flag"
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -25,7 +30,45 @@ func main() {
 	lo.Must0(cache.WaitForCacheSync(ctx))
 	c := lo.Must(client.New(config, client.Options{Cache: &client.CacheOptions{Reader: cache}}))
 
-	fmt.Println("time,node_total,node_ready,node_tainted,node_deleting,nodeclaim_total,nodeclaim_launched,nodeclaim_registered,nodeclaim_initialized,nodeclaim_drifted,nodeclaim_disrupted,nodeclaim_deleting")
+	// Define flags
+	outputFile := flag.String("o", "", "Output CSV file")
+	overwrite := flag.Bool("f", false, "Force overwrite if file exists")
+	flag.Parse()
+
+	// Check if file exists
+	_, err := os.Stat(*outputFile)
+	fileExists := !os.IsNotExist(err)
+
+	if fileExists && !*overwrite && lo.FromPtr(outputFile) != "" {
+		log.Fatalf("File %s already exists. Use -f flag to force overwrite", *outputFile)
+	}
+
+	file := &os.File{}
+	var multiWriter io.Writer
+	if lo.FromPtr(outputFile) != "" {
+		file, err = os.Create(lo.FromPtr(outputFile))
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		multiWriter = io.MultiWriter(
+			file,      // Write to file
+			os.Stdout, // Write to standard output
+		)
+	} else {
+		multiWriter = io.MultiWriter(
+			os.Stdout, // Write to standard output
+		)
+	}
+	csvWriter := csv.NewWriter(multiWriter)
+	defer file.Close()
+
+	head := []string{"time", "node_total", "node_ready", "node_unhealthy", "node_tainted", "node_deleting", "nodeclaim_total", "nodeclaim_launched", "nodeclaim_registered", "nodeclaim_initialized", "nodeclaim_drifted", "nodeclaim_disrupted", "nodeclaim_deleting"}
+	err = csvWriter.Write(head)
+	if err != nil {
+		panic(err)
+	}
+	csvWriter.Flush()
 	for {
 		nodeList := &corev1.NodeList{}
 		if err := c.List(ctx, nodeList); err != nil {
@@ -35,8 +78,8 @@ func main() {
 		if err := c.List(ctx, nodeClaimList); err != nil {
 			continue
 		}
-		var launchedCount, registeredCount, initializedCount, driftedCount, deletingCount, disruptedCount, nodeReadyCount, nodeDeletingCount, nodeTaintedCount atomic.Int64
-		workqueue.ParallelizeUntil(ctx, 100, len(nodeClaimList.Items), func(i int) {
+		var launchedCount, registeredCount, initializedCount, driftedCount, deletingCount, disruptedCount, nodeReadyCount, nodeUnhealthyCount, nodeDeletingCount, nodeTaintedCount atomic.Int64
+		workqueue.ParallelizeUntil(ctx, 1000, len(nodeClaimList.Items), func(i int) {
 			if nodeClaimList.Items[i].StatusConditions().Get(v1.ConditionTypeLaunched).IsTrue() {
 				launchedCount.Add(1)
 			}
@@ -56,9 +99,12 @@ func main() {
 				deletingCount.Add(1)
 			}
 		})
-		workqueue.ParallelizeUntil(ctx, 100, len(nodeList.Items), func(i int) {
+		workqueue.ParallelizeUntil(ctx, 1000, len(nodeList.Items), func(i int) {
 			if GetCondition(&nodeList.Items[i], corev1.NodeReady).Status == corev1.ConditionTrue {
 				nodeReadyCount.Add(1)
+			}
+			if GetCondition(&nodeList.Items[i], corev1.NodeConditionType("TestTypeReady")).Status == corev1.ConditionFalse {
+				nodeUnhealthyCount.Add(1)
 			}
 			if !nodeList.Items[i].DeletionTimestamp.IsZero() {
 				nodeDeletingCount.Add(1)
@@ -69,7 +115,12 @@ func main() {
 				nodeTaintedCount.Add(1)
 			}
 		})
-		fmt.Printf("%s,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n", time.Now().Format(time.RFC3339), len(nodeList.Items), nodeReadyCount.Load(), nodeTaintedCount.Load(), nodeDeletingCount.Load(), len(nodeClaimList.Items), launchedCount.Load(), registeredCount.Load(), initializedCount.Load(), driftedCount.Load(), disruptedCount.Load(), deletingCount.Load())
+		record := []string{time.Now().Format(time.TimeOnly), fmt.Sprint(len(nodeList.Items)), fmt.Sprint(nodeReadyCount.Load()), fmt.Sprint(nodeUnhealthyCount.Load()), fmt.Sprint(nodeTaintedCount.Load()), fmt.Sprint(nodeDeletingCount.Load()), fmt.Sprint(len(nodeClaimList.Items)), fmt.Sprint(launchedCount.Load()), fmt.Sprint(registeredCount.Load()), fmt.Sprint(initializedCount.Load()), fmt.Sprint(driftedCount.Load()), fmt.Sprint(disruptedCount.Load()), fmt.Sprint(deletingCount.Load())}
+		err = csvWriter.Write(record)
+		if err != nil {
+			panic(err)
+		}
+		csvWriter.Flush()
 		time.Sleep(time.Second * 5)
 	}
 }


### PR DESCRIPTION
## Summary
This PR enhances the Karpenter status poller by adding support for tracking unhealthy nodes in the cluster. The implementation includes:

- Created `chart/permissions.yaml` with ServiceAccount, ClusterRole, and ClusterRoleBinding for node/nodeclaim access
- Added `chart/pod.yaml` with deployment configuration for the CSV creator
- Modified `main.go` to:
  - Track unhealthy nodes with condition status "TestTypeReady=False"
  - Write output to a CSV file in addition to console output
  - Increase parallelization from 100 to 1000 for better performance
  - Format timestamps using TimeOnly format in the output